### PR TITLE
increase exec buffer size

### DIFF
--- a/src/spawn.ts
+++ b/src/spawn.ts
@@ -156,7 +156,7 @@ export async function exportGenesisWasm(
 
 	// wasm files are typically large and `exec` requires us to supply the maximum buffer size in
 	// advance. Hopefully, this generous limit will be enough.
-	let opts = { maxBuffer: 10 * 1024 * 1024 };
+	let opts = { maxBuffer: 32 * 1024 * 1024 };
 	verbose(bin, args);
 	let { stdout, stderr } = await execFile(bin, args, opts);
 	if (stderr) {


### PR DESCRIPTION
for the case of uncompressed wasm
because we speed up  and simplify builds for devs repl
and we do not care size of wasm